### PR TITLE
Fix newer python3 versions

### DIFF
--- a/cldoc/comment.py
+++ b/cldoc/comment.py
@@ -470,7 +470,6 @@ class CommentsDatabase(object):
 from pyparsing import *
 
 class Parser:
-    ParserElement.setDefaultWhitespaceChars(' \t\r')
 
     identifier = Word(alphas + '_', alphanums + '_')
 

--- a/setup.py
+++ b/setup.py
@@ -159,6 +159,6 @@ setup(name='cldoc',
       },
       package_data={'cldoc': datafiles},
       cmdclass=cmdclass,
-      install_requires=['pyparsing == 2.2.0'])
+      install_requires=['pyparsing == 3.1.1'])
 
 # vi:ts=4:et


### PR DESCRIPTION
Fixes `AttributeError: module 'collections' has no attribute 'MutableMapping'` on python3.10+